### PR TITLE
20 viessmann uri change

### DIFF
--- a/src/ViessmannClient/Network/ViessmannAuthBase.cs
+++ b/src/ViessmannClient/Network/ViessmannAuthBase.cs
@@ -19,8 +19,8 @@ namespace PhilipDaubmeier.ViessmannClient.Network
 
         private readonly HttpClient _client;
 
-        private const string _authUri = "https://iam.viessmann.com/idp/v2/authorize";
-        private const string _tokenUri = "https://iam.viessmann.com/idp/v2/token";
+        private const string _authUri = "https://iam.viessmann-climatesolutions.com/idp/v2/authorize";
+        private const string _tokenUri = "https://iam.viessmann-climatesolutions.com/idp/v2/token";
         private static readonly List<string> _scopes = new() { "IoT", "User", "offline_access" };
 
         private static readonly Semaphore _renewTokenSemaphore = new(1, 1);

--- a/src/ViessmannClient/README.md
+++ b/src/ViessmannClient/README.md
@@ -13,7 +13,7 @@ PM> Install-Package PhilipDaubmeier.ViessmannClient
 
 ## Usage
 
-For getting access to Viessmann APIs, first register on the [Viessmann Developer Portal](https://developer.viessmann.com/) and create a client via ["API Keys"](https://developer.viessmann.com/de/clients), which will generate a client id for you and lets you set one or more redirect URIs.
+For getting access to Viessmann APIs, first register on the [Viessmann Developer Portal](https://developer.viessmann-climatesolutions.com/) and create a client via ["API Keys"](https://developer.viessmann-climatesolutions.com/de/clients), which will generate a client id for you and lets you set one or more redirect URIs.
 
 To then use this library, you have to implement the interfaces `IViessmannAuth` and `IViessmannConnectionProvider<T>` to provide the Viessmann webservice clients with all information necessary to authenticate and establish a connection.
 

--- a/src/ViessmannClient/ViessmannClient.csproj
+++ b/src/ViessmannClient/ViessmannClient.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/philipdaubmeier/GraphIoT/tree/master/src/ViessmannClient</PackageProjectUrl>
     <Authors>PhilipDaubmeier</Authors>
     <Company>PhilipDaubmeier</Company>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>net9.0</TargetFrameworks>
     <NuspecFile>ViessmannClient.nuspec</NuspecFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/ViessmannClient/ViessmannClient.nuspec
+++ b/src/ViessmannClient/ViessmannClient.nuspec
@@ -12,6 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
+2.6.0 - updated all uris to new domain name (https://community.viessmann.de/t5/Announcements/Domain-Change-for-the-Viessmann-API/td-p/551560)
 2.5.0 - upgraded to target framework net9.0
 2.4.0 - upgraded to target framework net8.0
 2.3.0 - changed data point naming of burners according to Viessmann Developer Portal changelog

--- a/src/ViessmannClient/ViessmannPlatformClient.cs
+++ b/src/ViessmannClient/ViessmannPlatformClient.cs
@@ -11,7 +11,7 @@ namespace PhilipDaubmeier.ViessmannClient
 {
     public class ViessmannPlatformClient : ViessmannAuthBase
     {
-        private const string _baseUri = "https://api.viessmann.com/";
+        private const string _baseUri = "https://api.viessmann-climatesolutions.com/";
 
         public ViessmannPlatformClient(IViessmannConnectionProvider<ViessmannPlatformClient> connectionProvider)
             : base(connectionProvider) { }

--- a/test/ViessmannClient.Tests/MockViessmannConnection.cs
+++ b/test/ViessmannClient.Tests/MockViessmannConnection.cs
@@ -9,14 +9,14 @@ namespace PhilipDaubmeier.ViessmannClient.Tests
 {
     public static class MockViessmannConnection
     {
-        private const string _authUri = "https://iam.viessmann.com/idp/v2/authorize";
-        private const string _tokenUri = "https://iam.viessmann.com/idp/v2/token";
+        private const string _authUri = "https://iam.viessmann-climatesolutions.com/idp/v2/authorize";
+        private const string _tokenUri = "https://iam.viessmann-climatesolutions.com/idp/v2/token";
         private const string _redirectUri = "http://localhost:4000";
 
         private const string _clientId = "1234561unittestidf91d15ff4caceee";
         private const string _authorizationCode = "123_unittest_authorization_code_456";
         
-        public static string BaseUri => "https://api.viessmann.com/";
+        public static string BaseUri => "https://api.viessmann-climatesolutions.com/";
         public static string AppToken => "5f4d6babc_dummy_unittest_token_83025a07162890c80a8b587bea589b8e2";
         public static string RefreshToken => "9b22aceff_dummy_unittest_token_173cba864cbae45f34efa22bc47544111";
         public static string CodeChallenge => "SlvCf8TdHPDGMs-dummy-nHjgX-nRICB-fRtQ0Uhy7g";


### PR DESCRIPTION
Update all Viessmann URIs to their new `viessmann-climatesolutions.com` domain like announced here: [Domain Change for the Viessmann API - Viessmann Climate Solutions Community](https://community.viessmann.de/t5/Announcements/Domain-Change-for-the-Viessmann-API/td-p/551560).

Resolves issue #20