### PR TITLE
Netatmo domain change

### DIFF
--- a/src/NetatmoClient/NetatmoClient.csproj
+++ b/src/NetatmoClient/NetatmoClient.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/philipdaubmeier/GraphIoT/tree/master/src/NetatmoClient</PackageProjectUrl>
     <Authors>PhilipDaubmeier</Authors>
     <Company>PhilipDaubmeier</Company>
-    <Version>1.9.0</Version>
+    <Version>1.10.0</Version>
     <TargetFrameworks>net9.0</TargetFrameworks>
     <NuspecFile>NetatmoClient.nuspec</NuspecFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/NetatmoClient/NetatmoClient.nuspec
+++ b/src/NetatmoClient/NetatmoClient.nuspec
@@ -12,6 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
+1.10.0 - updated domain name of api endpoint after change by Netatmo
 1.9.0 - upgraded to target framework net9.0
 1.8.0 - upgraded to target framework net8.0
 1.7.0 - upgraded to target framework net5.0

--- a/src/NetatmoClient/Network/NetatmoAuthBase.cs
+++ b/src/NetatmoClient/Network/NetatmoAuthBase.cs
@@ -14,7 +14,7 @@ namespace PhilipDaubmeier.NetatmoClient.Network
     public abstract class NetatmoAuthBase : IDisposable
     {
         private const string _authUri = "https://api.netatmo.com/oauth2/authorize";
-        protected const string _baseUri = @"https://api.netatmo.net";
+        protected const string _baseUri = @"https://api.netatmo.com";
         private const string _state = "HwOdqNKAWeKl7";
 
         private static readonly Semaphore _renewTokenSemaphore = new(1, 1);

--- a/test/NetatmoClient.Tests/MockNetatmoConnection.cs
+++ b/test/NetatmoClient.Tests/MockNetatmoConnection.cs
@@ -13,7 +13,7 @@ namespace PhilipDaubmeier.NetatmoClient.Tests
         private const string _scope = "read_station read_presence access_presence";
         private const string _redirectUri = "http://localhost:4000";
 
-        public static string BaseUri => "https://api.netatmo.net";
+        public static string BaseUri => "https://api.netatmo.com";
         public static string AppToken => "5f4d6babc_dummy_unittest_token_83025a07162890c80a8b587bea589b8e2";
         public static string RefreshToken => "716289babc_dummy_unittest_refresh_token_83025a07162890587bea58987be";
 

--- a/test/NetatmoClient.Tests/MockNetatmoHome.cs
+++ b/test/NetatmoClient.Tests/MockNetatmoHome.cs
@@ -24,7 +24,7 @@ namespace PhilipDaubmeier.NetatmoClient.Tests
                                             ""id"": ""78:90:ab:cd:ef:01"",
                                             ""type"": ""NOC"",
                                             ""status"": ""on"",
-                                            ""vpn_url"": ""https://prodvpn-eu-123.netatmo.net/restricted/10.0.0.1/abcabc123412341234123412341234ab/MTABCDEFG1234ABCDEF1234BACDEF1234ABCDEF123,,"",
+                                            ""vpn_url"": ""https://prodvpn-eu-123.netatmo.com/restricted/10.0.0.1/abcabc123412341234123412341234ab/MTABCDEFG1234ABCDEF1234BACDEF1234ABCDEF123,,"",
                                             ""is_local"": false,
                                             ""sd_status"": ""on"",
                                             ""alim_status"": ""on"",

--- a/test/NetatmoClient.Tests/NetatmoWebClientTest.cs
+++ b/test/NetatmoClient.Tests/NetatmoWebClientTest.cs
@@ -212,7 +212,7 @@ namespace PhilipDaubmeier.NetatmoClient.Tests
             Assert.Equal("78:90:ab:cd:ef:01", result.Homes[0].Cameras[0].Id);
             Assert.Equal("NOC", result.Homes[0].Cameras[0].Type);
             Assert.Equal("on", result.Homes[0].Cameras[0].Status);
-            Assert.Equal("https://prodvpn-eu-123.netatmo.net/restricted/10.0.0.1/abcabc123412341234123412341234ab/MTABCDEFG1234ABCDEF1234BACDEF1234ABCDEF123,,", result.Homes[0].Cameras[0].VpnUrl);
+            Assert.Equal("https://prodvpn-eu-123.netatmo.com/restricted/10.0.0.1/abcabc123412341234123412341234ab/MTABCDEFG1234ABCDEF1234BACDEF1234ABCDEF123,,", result.Homes[0].Cameras[0].VpnUrl);
             Assert.False(result.Homes[0].Cameras[0].IsLocal);
             Assert.Equal("on", result.Homes[0].Cameras[0].SdStatus);
             Assert.Equal("on", result.Homes[0].Cameras[0].AlimStatus);


### PR DESCRIPTION
Change of API endpoint due to consolidation of domain names by Netatmo, see: https://dev.netatmo.com/apidocumentation/general

Fixes #22 